### PR TITLE
feat: roll out smurf stf checks

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -1,16 +1,16 @@
 name: tf-checks
 on:
   push:
-    branches: [ master ]
+    branches: [ faet/rollout-smurf ]
   pull_request:
   workflow_dispatch:
 jobs:
   basic-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
     with:
       working_directory: './_examples/basic/'
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
     with:
       working_directory: './_examples/complete/'
 

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -1,7 +1,7 @@
 name: tf-checks
 on:
   push:
-    branches: [ faet/rollout-smurf ]
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
- Rolls out Smurf STF checks for the Smurf CLI in the Terraform DigitalOcean repository
- Updates the shared STF workflow reference from
- 88efd7724e007c8f721a219498be29e0c9ad471b → c615ea7ef3e5beba98a335bf9acce8e67e03c755
- Pins the workflow to the referenced commit to ensure stable and reproducible CI runs
